### PR TITLE
Disable Growl notifications when running tests

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,1 @@
---growl --ui tdd --require test/helper.js
+--ui tdd --require test/helper.js


### PR DESCRIPTION
Because a large number of tests are run programatically, there are far
too many Growl notifications generated than are helpful.
