### PR TITLE
Export Reporter.write to be able to use the IPC

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-json-proxy",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "author": "James Lal [:lightsofapollo]",
   "description": "Mocha JSON proxy reporter",
   "main": "consumer",

--- a/reporter.js
+++ b/reporter.js
@@ -133,6 +133,8 @@ function Reporter(runner) {
   }, this);
 }
 
+Reporter.write = write;
+
 Reporter.prototype = Object.create(Base.prototype);
 
 Reporter.FORK_ENV = 'MOCHA_PROXY_SEND_ONLY';


### PR DESCRIPTION
This is for bug 915156

@lightsofapollo: I'd like to have Reporter.write exposed to seen custom data over the IPC. Currently I copy the "write()" function, but this is ugly.
